### PR TITLE
Make possible to use a database in a different host

### DIFF
--- a/core_install.sh
+++ b/core_install.sh
@@ -10,6 +10,7 @@ set -e
 
 DATABASENAME=oc_autotest
 DATABASEUSER=oc_autotest
+[ -z "$DATABASEHOST" ] && DATABASEHOST="localhost"
 ADMINLOGIN=admin
 BASEDIR=$PWD
 
@@ -64,7 +65,7 @@ cat > ./tests/autoconfig-mysql.php <<DELIM
   'directory' => '$DATADIR',
   'dbuser' => '$DATABASEUSER',
   'dbname' => '$DATABASENAME',
-  'dbhost' => 'localhost',
+  'dbhost' => '$DATABASEHOST',
   'dbpass' => 'owncloud',
 );
 DELIM
@@ -80,7 +81,7 @@ cat > ./tests/autoconfig-pgsql.php <<DELIM
   'directory' => '$DATADIR',
   'dbuser' => '$DATABASEUSER',
   'dbname' => '$DATABASENAME',
-  'dbhost' => 'localhost',
+  'dbhost' => '$DATABASEHOST',
   'dbpass' => '',
 );
 DELIM


### PR DESCRIPTION
The _before_install.sh_ and _core_install.sh_ scripts assumed that the MySQL and PostgreSQL databases are in the same host as the server. This is the case when used in Travis CI, but not when used in Drone; in that later case the server and the database are in different containers. This pull request makes possible to use those scripts in Travis CI just like before, but also in Drone with MySQL and PostgreSQL databases.

The scripts now take into account the `$DATABASEHOST` environment variable; if it is not set or it is set to `localhost` everything works like before. However, if it is set to a different value then instead of creating the database _before_install.sh_ just waits for the database to be up ([using the same technique as in the _autotest.sh_ script from the server](https://github.com/nextcloud/server/blob/df6e23c98ce3d5a50c417a085f2095f42b663efa/autotest.sh#L218)), and _core_install.sh_ uses that value as the database host during the installation of the server.

Note that `$DATABASEHOST` is ignored when using SQLite (the local host is always used in that case). Also, Oracle was not taken into account in the changes of this pull request.

Finally, an example of how to use this in Drone can be seen in nextcloud/spreed#648
