### PR TITLE
Adjust the timeout for postgres to the one of mysql

### DIFF
--- a/before_install.sh
+++ b/before_install.sh
@@ -44,8 +44,8 @@ if [ "$DB" == "pgsql" ] ; then
     createuser -U travis -s oc_autotest
   else
     echo "Waiting for Postgres to be available ..."
-    if ! ../server/apps/files_external/tests/env/wait-for-connection $DATABASEHOST 5432 60; then
-      echo "[ERROR] Waited 60 seconds for $DATABASEHOST, no response" >&2
+    if ! ../server/apps/files_external/tests/env/wait-for-connection $DATABASEHOST 5432 600; then
+      echo "[ERROR] Waited 600 seconds for $DATABASEHOST, no response" >&2
       exit 1
     fi
     echo "Give it 10 additional seconds ..."


### PR DESCRIPTION
Since ~2 weeks the fail quote of postgres increased to ~80% because the start up is taking longer than expected, e.g.:
https://drone.nextcloud.com/nextcloud/spreed/5697/10/4

MySQL also uses 10mins, so let's try that.